### PR TITLE
Improve LinuxMain.swift generation

### DIFF
--- a/Tests/LinuxMain.stencil
+++ b/Tests/LinuxMain.stencil
@@ -1,9 +1,15 @@
-{% for type in types.based.TestCase|!protocol %}
-	// sourcery:inline:auto:{{ type.name }}.Tests
-	static let allTests = [
-		{% for func in type.methods where func.shortName|hasPrefix:"test" %}
-		("{{ func.shortName }}", {{ func.shortName }}),
-		{% endfor %}
-	]
-	// sourcery:end
-{% endfor %}
+// sourcery:inline:auto:LinuxMain
+
+{% for type in types.classes|based:"TestCase" %}
+{% if not type.annotations.excludeFromLinuxMain %}extension {{ type.name }} {
+  static var allTests = [
+  {% for method in type.methods %}{% if method.parameters.count == 0 and method.shortName|hasPrefix:"test" %}  ("{{ method.shortName }}", {{ method.shortName }}),
+  {% endif %}{% endfor %}]
+}
+
+{% endif %}{% endfor %}
+XCTMain([
+{% for type in types.classes|based:"XCTestCase" %}{% if not type.annotations.excludeFromLinuxMain %}  testCase({{ type.name }}.allTests),
+{% endif %}{% endfor %}])
+
+// sourcery:end


### PR DESCRIPTION
- auto extension for test cases
- ability to exclude classes using `//sourcery:excludeFromLinuxMain`