### PR TITLE
Align line breaks, use bools and unique fallback

### DIFF
--- a/Controllers/RouteCollection.stencil
+++ b/Controllers/RouteCollection.stencil
@@ -2,7 +2,6 @@
 
 {% for type in types.all|!protocol|annotated:"controller" %}
 // sourcery:file:Routes/{{ type.localName }}/{{ type.localName }}+RouteCollection.generated.swift
-
 import Vapor
 
 extension {{ type.localName }}: RouteCollection {

--- a/Models/JSONConvertible.stencil
+++ b/Models/JSONConvertible.stencil
@@ -2,7 +2,6 @@
 
 {% for type in types.based.Model|!protocol|annotated:"model"|!annotated:"ignoreJSONConvertible" %}
 // sourcery:file:Models/{{ type.localName }}/{{ type.localName }}+JSONConvertible.generated.swift
-
 import Vapor
 import Fluent
 {% if type.annotations.import %}
@@ -14,7 +13,7 @@ import {{ var }}
 {% endif %}
 
 extension {{ type.localName }}: JSONConvertible {
-    internal enum JSONKeys: String {
+    internal enum JSONKeys {
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible" %}
         static let {{ var.annotations.jsonKey|default:var.name }} = "{{ var.annotations.jsonKey|default:var.name }}"
         {% endfor %}

--- a/Models/NodeRepresentable.stencil
+++ b/Models/NodeRepresentable.stencil
@@ -2,7 +2,6 @@
 
 {% for type in types.based.Model|!protocol|annotated:"model"|!annotated:"ignoreNodeRepresentable" %}
 // sourcery:file:Models/{{ type.localName }}/{{ type.localName }}+NodeRepresentable.generated.swift
-
 import Vapor
 import Fluent
 {% if type.annotations.import %}
@@ -14,7 +13,7 @@ import {{ var }}
 {% endif %}
 
 extension {{ type.localName }}: NodeRepresentable {
-    internal enum NodeKeys: String {
+    internal enum NodeKeys {
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreNodeRepresentable" %}
         static let {{ var.annotations.nodeKey|default:var.name }} = "{{ var.annotations.nodeKey|default:var.name }}"
         {% endfor %}

--- a/Models/Preparation.stencil
+++ b/Models/Preparation.stencil
@@ -2,7 +2,6 @@
 
 {% for type in types.based.Model|!protocol|annotated:"model"|!annotated:"ignorePreparation" %}
 // sourcery:file:Models/{{ type.localName }}/{{ type.localName }}+Preparation.generated.swift
-
 import Vapor
 import Fluent
 {% if type.annotations.import %}
@@ -26,7 +25,7 @@ extension {{ type.localName }}: Preparation {
         try database.create(self) {
             $0.id()
             {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignorePreparation" %}
-            $0.{% if var|annotated:"preparation" %}{{ var.annotations.preparation }}{% elif var.type.based.RawStringConvertible %}enum{% else %}{{ var.typeName.description|lowercase|replace:"?","" }}{% endif %}{% if var.annotations.preparation == "foreignId" %}(for: {{ var.annotations.foreignTable }}.self, optional: {{ var.isOptional }}, unique: {{ var.annotations.unique }}, foreignIdKey: {% if var.annotations.foreignIdKey %}"{{ var.annotations.foreignIdKey }}"{% else %}DatabaseKeys.{{ var.name }}{% if var.annotations.foreignKeyName %}, foreignKeyName: "{{ var.annotations.foreignKeyName }}"{% endif %}{% endif %}){% elif var.type.based.RawStringConvertible %}(DatabaseKeys.{% if var.annotations.databaseKey %}{{ var.annotations.databaseKey }}{% else %}{{ var.name }}{% endif %}, options: {{ var.typeName }}.allRaw){% else %}(DatabaseKeys.{% if var.annotations.databaseKey %}{{ var.annotations.databaseKey }}{% else %}{{ var.name }}{% endif %}{% if var.annotations.type %}, type: "{{ var.annotations.type }}"{% endif %}{% if var.isOptional %}, optional: true{% endif %}{% if var.annotations.unique %}, unique: true{% endif %}){% endif %}
+            $0.{% if var|annotated:"preparation" %}{{ var.annotations.preparation }}{% elif var.type.based.RawStringConvertible %}enum{% else %}{{ var.typeName.description|lowercase|replace:"?","" }}{% endif %}{% if var.annotations.preparation == "foreignId" %}(for: {{ var.annotations.foreignTable }}.self{% if var.isOptional %}, optional: true{% endif %}{% if var.annotations.unique %}, unique: {{ var.annotations.unique }}{% endif %}, foreignIdKey: {% if var.annotations.foreignIdKey %}"{{ var.annotations.foreignIdKey }}"{% else %}DatabaseKeys.{{ var.name }}{% if var.annotations.foreignKeyName %}, foreignKeyName: "{{ var.annotations.foreignKeyName }}"{% endif %}{% endif %}){% elif var.type.based.RawStringConvertible %}(DatabaseKeys.{% if var.annotations.databaseKey %}{{ var.annotations.databaseKey }}{% else %}{{ var.name }}{% endif %}, options: {{ var.typeName }}.allRaw){% else %}(DatabaseKeys.{% if var.annotations.databaseKey %}{{ var.annotations.databaseKey }}{% else %}{{ var.name }}{% endif %}{% if var.annotations.type %}, type: "{{ var.annotations.type }}"{% endif %}{% if var.isOptional %}, optional: true{% endif %}{% if var.annotations.unique %}, unique: {{ var.annotations.unique }}{% endif %}){% endif %}
             {% endfor %}
         }
 

--- a/Models/RowConvertible.stencil
+++ b/Models/RowConvertible.stencil
@@ -2,7 +2,6 @@
 
 {% for type in types.based.Model|!protocol|annotated:"model"|!annotated:"ignoreRowConvertible" %}
 // sourcery:file:Models/{{ type.localName }}/{{ type.localName }}+RowConvertible.generated.swift
-
 import Vapor
 import Fluent
 


### PR DESCRIPTION
Fixed:
- Aligned the line breaks at top of file across the files
- `unique` is an optional annotation for the preparations (`foreignId`)
- Optionals are now correctly transformed to `Bool` in the preparation