### PR TITLE
Added more granular ignoring mechanism for JSONConvertible

### DIFF
--- a/Models/JSONConvertible.stencil
+++ b/Models/JSONConvertible.stencil
@@ -22,7 +22,7 @@ extension {{ type.localName }}: JSONConvertible {
     // MARK: - JSONConvertible ({{ type.name }})
     internal convenience init(json: JSON) throws {
         try self.init(
-            {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible" %}
+            {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible"|!annotated:"ignoreJSONInitializable" %}
             {{ var.name }}: json.get(JSONKeys.{{ var.annotations.jsonKey|default:var.name }}){% if not forloop.last %},{% endif %}
             {% endfor %}
         )
@@ -32,7 +32,7 @@ extension {{ type.localName }}: JSONConvertible {
         var json = JSON()
 
         try json.set({{ type.name }}.idKey, id)
-        {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible" %}
+        {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible"|!annotated:"ignoreJSONRepresentable" %}
         try json.set(JSONKeys.{{ var.annotations.jsonKey|default:var.name }}, {{ var.annotations.jsonValue|default:var.name}})
         {% endfor %}
 

--- a/README.md
+++ b/README.md
@@ -288,11 +288,13 @@ extension User: ResponseRepresentable {}
 
 #### Annotations
 
-| Key                     | Description                              |
-| ----------------------- | ---------------------------------------- |
-| `jsonValue`             | Set the value for JSON serialization.    |
-| `ignore`                | Prevents the property from being included in the generated code. |
-| `ignoreJSONConvertible` | Prevents the property from being included in the generated `JSONConvertible` code. |
+| Key                       | Description                              |
+| ------------------------- | ---------------------------------------- |
+| `jsonValue`               | Set the value for JSON serialization.    |
+| `ignore`                  | Prevents the property from being included in the generated code. |
+| `ignoreJSONConvertible`   | Prevents the property from being included in the generated `JSONConvertible` code. |
+| `ignoreJSONInitializable` | Prevents the property from being included in the `init(json:)` method of the generated `JSONConvertible` code. |
+| `ignoreJSONRepresentable` | Prevents the property from being included in the `makeJSON()` method of the generated `JSONConvertible` code. |
 
 ## Controllers
 These templates are for controllers and route collections. To make Sourcery pick up your controller, annotate your controller with `controller` :


### PR DESCRIPTION
Having a more granular `ignoreJSONInitializable` and `ignoreJSONRepresentable` allows you, for example, to have `password` property on `User` that you want in the `init(json:)` method but don't want to return in JSON response.