### PR TITLE
Use the types' accessLevels for extensions

### DIFF
--- a/Controllers/RouteCollection.stencil
+++ b/Controllers/RouteCollection.stencil
@@ -5,7 +5,7 @@
 import Vapor
 
 extension {{ type.localName }}: RouteCollection {
-    func build(_ builder: RouteBuilder) throws {
+    {{ type.accessLevel }} func build(_ builder: RouteBuilder) throws {
         builder.group("{{ type.annotations.group }}") { routes in
             {% for func in type.methods where func|annotated:"route" %}
             // {{ func.annotations.method|uppercase }} /{{ type.annotations.group }}{{ func.annotations.path }}

--- a/General/Enum.stencil
+++ b/General/Enum.stencil
@@ -54,13 +54,13 @@ extension RawStringConvertible  {
 {% for enum in types.enums|!annotated:"ignore" where arguments.enumOptOut or enum.annotations.enum or enum.based.RawStringConvertible %}
 
 extension {{ enum.name }} {
-    static var all: [{{ enum.name }}] = [
+    {{ type.accessLevel }} static var all: [{{ enum.name }}] = [
         {% for case in enum.cases %}
         .{{ case.name }},
         {% endfor %}
     ]
 
-    static let allRaw = {{ enum.name }}.all.map { $0.rawValue }
+    {{ type.accessLevel }} static let allRaw = {{ enum.name }}.all.map { $0.rawValue }
 }
 
 {% endfor %}

--- a/Models/JSON.stencil
+++ b/Models/JSON.stencil
@@ -15,7 +15,7 @@ import {{ var }}
 extension {{ type.localName }} {
     {{ type.accessLevel }} enum JSONKeys {
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible" %}
-        static let {{ var.annotations.jsonKey|default:var.name }} = "{{ var.annotations.jsonKey|default:var.name }}"
+        {{ type.accessLevel }} static let {{ var.annotations.jsonKey|default:var.name }} = "{{ var.annotations.jsonKey|default:var.name }}"
         {% endfor %}
     }
 }

--- a/Models/JSON.stencil
+++ b/Models/JSON.stencil
@@ -13,7 +13,7 @@ import {{ var }}
 {% endif %}
 
 extension {{ type.localName }} {
-    internal enum JSONKeys {
+    {{ type.accessLevel }} enum JSONKeys {
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible" %}
         static let {{ var.annotations.jsonKey|default:var.name }} = "{{ var.annotations.jsonKey|default:var.name }}"
         {% endfor %}
@@ -24,7 +24,7 @@ extension {{ type.localName }} {
 // MARK: - JSONInitializable ({{ type.name }})
 
 extension {{ type.localName }}: JSONInitializable {
-    internal convenience init(json: JSON) throws {
+    {{ type.accessLevel }} convenience init(json: JSON) throws {
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreJSONConvertible"|!annotated:"ignoreJSONInitializable" %}
         let {{var.name}}: {{var.typeName}} = try json.get(JSONKeys.{{ var.annotations.jsonKey|default:var.name }})
         {% endfor %}
@@ -42,7 +42,7 @@ extension {{ type.localName }}: JSONInitializable {
 // MARK: - JSONRepresentable ({{ type.name }})
 
 extension {{ type.localName }}: JSONRepresentable {
-    internal func makeJSON() throws -> JSON {
+    {{ type.accessLevel }} func makeJSON() throws -> JSON {
         var json = JSON()
 
         try json.set({{ type.name }}.idKey, id)

--- a/Models/Model.stencil
+++ b/Models/Model.stencil
@@ -2,9 +2,9 @@
 
 {% for type in types.based.Model|!protocol|annotated:"model" %}
     // sourcery:inline:auto:{{ type.name }}.Models
-    internal let storage = Storage()
+    {{ type.accessLevel }} let storage = Storage()
 
-    internal init(
+    {{ type.accessLevel }} init(
         {% for var in type.storedVariables|!annotated:"ignore" %}
         {{ var.name }}: {{ var.typeName.description }}{% if var.isOptional %} = nil{% endif %}{% if not forloop.last %},{% endif %}
         {% endfor %}

--- a/Models/NodeRepresentable.stencil
+++ b/Models/NodeRepresentable.stencil
@@ -13,14 +13,14 @@ import {{ var }}
 {% endif %}
 
 extension {{ type.localName }}: NodeRepresentable {
-    internal enum NodeKeys {
+    {{ type.accessLevel }} enum NodeKeys {
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreNodeRepresentable" %}
         static let {{ var.annotations.nodeKey|default:var.name }} = "{{ var.annotations.nodeKey|default:var.name }}"
         {% endfor %}
     }
 
     // MARK: - NodeRepresentable ({{ type.name }})
-    func makeNode(in context: Context?) throws -> Node {
+    {{ type.accessLevel }} func makeNode(in context: Context?) throws -> Node {
         var node = Node([:])
 
         try node.set({{ type.name }}.idKey, id)

--- a/Models/NodeRepresentable.stencil
+++ b/Models/NodeRepresentable.stencil
@@ -15,7 +15,7 @@ import {{ var }}
 extension {{ type.localName }}: NodeRepresentable {
     {{ type.accessLevel }} enum NodeKeys {
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreNodeRepresentable" %}
-        static let {{ var.annotations.nodeKey|default:var.name }} = "{{ var.annotations.nodeKey|default:var.name }}"
+        {{ type.accessLevel }} static let {{ var.annotations.nodeKey|default:var.name }} = "{{ var.annotations.nodeKey|default:var.name }}"
         {% endfor %}
     }
 

--- a/Models/Preparation.stencil
+++ b/Models/Preparation.stencil
@@ -13,7 +13,7 @@ import {{ var }}
 {% endif %}
 
 extension {{ type.localName }}: Preparation {
-    internal enum DatabaseKeys {
+    {{ type.accessLevel }} enum DatabaseKeys {
         static let id = {{ type.localName }}.idKey
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignorePreparation" %}
         static let {{ var.annotations.databaseKey|default:var.name }} = "{{ var.annotations.databaseKey|default:var.name }}"
@@ -21,7 +21,7 @@ extension {{ type.localName }}: Preparation {
     }
 
     // MARK: - Preparations ({{ type.name }})
-    internal static func prepare(_ database: Database) throws {
+    {{ type.accessLevel }} static func prepare(_ database: Database) throws {
         try database.create(self) {
             $0.id()
             {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignorePreparation" %}
@@ -34,7 +34,7 @@ extension {{ type.localName }}: Preparation {
         {% endfor %}
     }
 
-    internal static func revert(_ database: Database) throws {
+    {{ type.accessLevel }} static func revert(_ database: Database) throws {
         try database.delete(self)
     }
 }

--- a/Models/Preparation.stencil
+++ b/Models/Preparation.stencil
@@ -14,9 +14,9 @@ import {{ var }}
 
 extension {{ type.localName }}: Preparation {
     {{ type.accessLevel }} enum DatabaseKeys {
-        static let id = {{ type.localName }}.idKey
+        {{ type.accessLevel }} static let id = {{ type.localName }}.idKey
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignorePreparation" %}
-        static let {{ var.annotations.databaseKey|default:var.name }} = "{{ var.annotations.databaseKey|default:var.name }}"
+        {{ type.accessLevel }} static let {{ var.annotations.databaseKey|default:var.name }} = "{{ var.annotations.databaseKey|default:var.name }}"
         {% endfor %}
     }
 

--- a/Models/RowConvertible.stencil
+++ b/Models/RowConvertible.stencil
@@ -7,7 +7,7 @@ import Fluent
 
 extension {{ type.localName }}: RowConvertible {
     // MARK: - RowConvertible ({{ type.name }})
-    convenience internal init (row: Row) throws {
+    convenience {{ type.accessLevel }} init (row: Row) throws {
         try self.init(
             {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreRowConvertible" %}
             {{ var.name }}: row.get(DatabaseKeys.{{ var.annotations.databaseKey|default:var.name }}){% if not forloop.last %},{% endif %}
@@ -15,7 +15,7 @@ extension {{ type.localName }}: RowConvertible {
         )
     }
 
-    internal func makeRow() throws -> Row {
+    {{ type.accessLevel }} func makeRow() throws -> Row {
         var row = Row()
 
         {% for var in type.storedVariables|!annotated:"ignore"|!annotated:"ignoreRowConvertible" %}


### PR DESCRIPTION
This enables sourcery to be used for public models and controllers